### PR TITLE
Update configuration.md

### DIFF
--- a/docs/en/framework/api-development/standard-apis/configuration.md
+++ b/docs/en/framework/api-development/standard-apis/configuration.md
@@ -55,7 +55,16 @@ namespace Acme.BookStore.Web
 }
 ```
 
+Add your contributor instance to the `AbpApplicationConfigurationOptions`
+
+```csharp
+Configure<AbpApplicationConfigurationOptions>(options =>
+{
+    options.Contributors.AddIfNotContains(new MyApplicationConfigurationContributor());
+});
+```
+
 * `IApplicationConfigurationContributor` defines the `ContributeAsync` method to extend the **application-configuration** endpoint with the specified additional data.
 * You can inject services and perform any logic needed to extend the endpoint as you wish.
 
-> Application configuration contributors are automatically discovered by the ABP and executed as a part of the application configuration initialization process.
+> Application configuration contributors are executed as a part of the application configuration initialization process.


### PR DESCRIPTION
### Description

IApplicationConfigurationContributor is not auto discovered as documented unless explicitly added to in ConfigureService.

This was initially discovered and reported by @nurlix here https://github.com/abpframework/abp/issues/19879 
It was fixed by @maliming in PR: https://github.com/abpframework/abp/pull/19900

However the file was deleted in PR https://github.com/abpframework/abp/pull/20352 and this update didn't go through new doc. system.

This PR re-updates configuration.md document to reflect latest status.
